### PR TITLE
Update syntax definitions to add more support for functions and parameterized types

### DIFF
--- a/syntax/soy.tmLanguage.json
+++ b/syntax/soy.tmLanguage.json
@@ -31,14 +31,10 @@
 					"patterns": [
 						{
 							"name": "entity.name.tag",
-							"match": "\\b(sp|literal|else|default|nil|lb|rb|ifempty|fallbackmsg)\\b"
+							"match": "\\b(and|case|default|elseif|else|fallbackmsg|false|foreach|for|ifempty|if|in|lb|let|literal|msg|nil|not|null|or|print|rb|sp|switch|true)\\b"
 						},
 						{
-							"name": "entity.name.tag",
-							"match": "\\b(foreach|if|elseif|switch|case|let|for|in|msg|print)\\b"
-						},
-						{
-							"match": "(@param\\??) ([\\w\\d]+): ?([\\w\\d.]+)?",
+							"match": "(@param\\??) ([\\w\\d]+): ?(?:([\\w\\d.]+)(?:<([\\w\\d.]+)>)?)?",
 							"captures": {
 								"1": {
 									"name": "entity.name.type"
@@ -48,22 +44,14 @@
 								},
 								"3": {
 									"name": "support.function"
-								}
-							}
-						},
-						{
-							"match": "\\b(deltemplate|template) ([\\w\\d.]+)",
-							"captures": {
-								"1": {
-									"name": "entity.name.tag"
 								},
-								"2": {
-									"name": "variable.parameter"
+								"4": {
+									"name": "support.function"
 								}
 							}
 						},
 						{
-							"match": "\\b(call|delcall) ([\\w\\d.]+)?",
+							"match": "\\b(deltemplate|template|call|delcall|namespace|delpackage|package)\\b(?: ([\\w\\d.]+))?",
 							"captures": {
 								"1": {
 									"name": "entity.name.tag"
@@ -93,42 +81,34 @@
 							}
 						},
 						{
-							"match": "\\b(namespace|delpackage|package) ([\\w\\d.]*)",
-							"captures": {
-								"1": {
-									"name": "entity.name.tag"
-								},
-								"2": {
-									"name": "variable.parameter"
-								}
-							}
-						},
-						{
-							"match": "\\b(alias) ([\\w.]*)",
+							"match": "\\b(alias) ([\\w\\d.]*)(?: (as) ([\\w\\d.]*))?",
 							"captures": {
 								"1": {
 									"name": "entity.name.type"
 								},
 								"2": {
-									"name": "constant.other"
+									"name": "variable.parameter"
+								},
+								"3": {
+									"name": "entity.name.type"
+								},
+								"4": {
+									"name": "variable.parameter"
 								}
 							}
-						},
-						{
-							"name": "entity.name.tag",
-							"match": "/\\b(deltemplate|template|foreach|msg|for|call|delcall|let|param|if|switch|literal)\\b"
 						},
 						{
 							"name": "variable.parameter",
 							"match": "\\$[\\w\\d.?\\[\\]]+"
 						},
 						{
-							"name": "entity.name.tag",
-							"match": "\\b(not|or|and|true|false|null)\\b"
+							"name": "keyword.control",
+							"match": "\\b(isFirst|isLast|index|quoteKeysIfJs|i18n(JS)?|setClientData)\\b"
 						},
 						{
+							"comment": "Built-in functions. See https://github.com/google/closure-templates/tree/master/java/src/com/google/template/soy/basicfunctions",
 							"name": "keyword.control",
-							"match": "\\b(length|isFirst|isLast|index|isNonnull|keys|range|augmentMap|quoteKeysIfJs|round|floor|ceiling|min|max|randomInt|strContains|i18n(JS)?|setClientData)\\b"
+							"match": "\\b(augmentMap|ceiling|concatLists|floor|htmlToText|isNonnull|isNull|join|keys|legacyObjectMapToMap|length|listContains|mapKeys|mapToLegacyObjectMap|max|min|parseFloat|parseInt|randomInt|range|round|sqrt|strContains|strIndexOf|strLen|strSmsUriToUri|strSub|strToAsciiLowerCase|strToAsciiUpperCase)\\b"
 						},
 						{
 							"name": "support.function",


### PR DESCRIPTION
Hey there,

I've made a few changes here:

1. Merged some of the duplicated pattern matchers (eg: there were 3 matchers for 'entity.name.tag'). I've put these all together into one big regex, which might not be super readable (though they are alphabetized now). If that's a problem, it'd probably be fine to split it up into multiple matchers again, grouping by the type of token (eg: true, false, null and nil in one group; if, else, switch etc in another)
2. Similarly, there were some matchers for call/delcall/template/deltemplate which could be merged.
3. the `{alias}` directive allows for this syntax `{alias some.namespace as foo}` so that's supported now.
4. Some types can take parameters, eg: `{param foo: list<number>}`. Previously the `<number>` part wasn't highlighted, but now it is.
5. Added the full list of built-in functions that soy supports, pulled from the files in the [closure-templates repo](https://github.com/google/closure-templates/tree/master/java/src/com/google/template/soy/basicfunctions)