### PR TITLE
adding configuration to exclude filepaths

### DIFF
--- a/client/src/files.ts
+++ b/client/src/files.ts
@@ -7,7 +7,7 @@ import { getExtensionConfiguration } from './utils';
 function excludeFromFileSearch(wsPath:string): string[] {
     return [
         path.join('!**', 'node_modules'),
-        ...getExtensionConfiguration().excludePaths.map(excludedPath => path.join('!',wsPath,excludedPath))
+        ...getExtensionConfiguration().excludePaths.map(excludedPath => '!' + path.join(wsPath,excludedPath))
     ]
 };
 

--- a/client/src/files.ts
+++ b/client/src/files.ts
@@ -2,10 +2,14 @@ import vscode = require('vscode');
 import fg = require('fast-glob');
 import path = require('path');
 import { ExtensionData } from './constants';
+import { getExtensionConfiguration } from './utils';
 
-const excludeFromFileSearch: string[] = [
-    path.join('!**', 'node_modules')
-];
+function excludeFromFileSearch(wsPath:string): string[] {
+    return [
+        path.join('!**', 'node_modules'),
+        ...getExtensionConfiguration().excludePaths.map(excludedPath => path.join('!',wsPath,excludedPath))
+    ]
+};
 
 export function getSoyFiles (): Thenable<string[][]> {
     const promises = [];
@@ -13,7 +17,7 @@ export function getSoyFiles (): Thenable<string[][]> {
     vscode.workspace.workspaceFolders.forEach(wsFolder => {
         const globalSoyFilesPath = path.join(wsFolder.uri.fsPath, '**', '*.soy');
 
-        promises.push(fg.async([globalSoyFilesPath, ...excludeFromFileSearch]));
+        promises.push(fg.async([globalSoyFilesPath, ...excludeFromFileSearch(wsFolder.uri.fsPath)]));
     });
 
     return Promise.all(promises);

--- a/package.json
+++ b/package.json
@@ -81,6 +81,14 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Disallows allowemptydefault in delcalls. It will be marked as an Error."
+                },
+                "soyLanguageServer.excludePaths": {
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Configure glob patterns for excluding files and folders from being indexed for template definitions."
                 }
             }
         },


### PR DESCRIPTION
Hello, 

My company's soy repositories are set up in a way that includes two copies of each soy file, one source version and one 'compiled' output version. This causes the Go To Definition functionality to always produce multiple results even though I only care about one of them. 

I added an option to exclude certain filepaths which has solved the problem for me locally. I wondered if you would be willing to accept it as a feature. I'm happy to make changes if the feature is ok but this isn't your preferred way to do it.

