### PR TITLE
Fix highlighting when there is more than two imported symbols.

### DIFF
--- a/syntax/soy.tmLanguage.json
+++ b/syntax/soy.tmLanguage.json
@@ -286,7 +286,7 @@
 					"include": "#strings"
 				},
 				{
-					"match": "\\s+(\\*)\\s+(as)\\s+(\\w+)\\s+(from)\\b",
+					"match": "\\s+(\\*)\\s+(as)\\s+(\\w+)",
 					"captures": {
 						"1": {
 							"name": "support.variable"
@@ -296,41 +296,51 @@
 						},
 						"3": {
 							"name": "variable.parameter"
-						},
-						"4": {
-							"name": "entity.name.tag"
 						}
 					}
 				},
 				{
-					"match": "({)\\s*((\\w+)(\\s+(as)\\s+(\\w+))?)(\\s*,\\s*(\\w+)(\\s+(as)\\s+(\\w+))?)*\\s*(})\\s*(from)\\b",
+					"begin": "{",
+					"end": "}",
+					"beginCaptures": {
+						"0": {
+							"name": "support.variable"
+						}
+					},
+					"endCaptures": {
+						"0": {
+							"name": "support.variable"
+						}
+					},
+					"patterns": [
+						{
+							"match": "(\\w+)(\\s+(as)\\s+(\\w+))?\\s*,?",
+							"captures": {
+								"1": {
+									"name": "variable.parameter"
+								},
+								"3": {
+									"name": "entity.name.tag"
+								},
+								"4": {
+									"name": "variable.parameter"
+								}
+							}
+						}
+					]
+				},
+				{
+					"name": "entity.name.tag",
+					"match": "\\bfrom\\b"
+				},
+				{
+					"match": "\\*\\s+(as)\\s+(\\w+)",
 					"captures": {
-						"1": {
-							"name": "support.variable"
-						},
-						"3": {
-							"name": "variable.parameter"
-						},
-						"5": {
+						"1":{
 							"name": "entity.name.tag"
 						},
-						"6": {
+						"2": {
 							"name": "variable.parameter"
-						},
-						"8": {
-							"name": "variable.parameter"
-						},
-						"10": {
-							"name": "entity.name.tag"
-						},
-						"11": {
-							"name": "variable.parameter"
-						},
-						"12": {
-							"name": "support.variable"
-						},
-						"13": {
-							"name": "entity.name.tag"
 						}
 					}
 				}


### PR DESCRIPTION
Fix the highlighting for import statements when there is more than two imported symbols. E.g.

```
import {foo, bar, baz as b} from 'foo.soy';
```