### PR TITLE
Add syntax highlighting for types in @param

### DIFF
--- a/syntax/soy.tmLanguage.json
+++ b/syntax/soy.tmLanguage.json
@@ -66,27 +66,28 @@
 							"match": "\\b(and|case|debugger|default|elseif|else|export|extern|fallbackmsg|false|foreach|for|ifempty|if|in|javaimpl|jsimpl|lb|let|log|key|msg|nil|not|null|or|plural|print|rb|sp|switch|true|velog)\\b"
 						},
 						{
-							"match": "(@(param|inject|state|attribute)\\??)\\s+([\\w\\d]+)\\s*:\\s*(?:([\\w\\d.]+)(?:<([\\w\\d.]+)>)?)?",
-							"captures": {
+							"begin": "(@(param|inject|state|attribute)\\??)\\s+([\\w\\d]+)\\s*:",
+							"end": "(=(?!>))|(?=\\})",
+							"beginCaptures": {
 								"1": {
-									"name": "entity.name.type"
+									"name": "entity.name.tag"
 								},
 								"3": {
 									"name": "variable.parameter"
-								},
-								"4": {
-									"name": "support.function"
-								},
-								"5": {
-									"name": "support.function"
 								}
-							}
+							},
+							"endCaptures": {},
+							"patterns": [
+								{
+									"include": "#soy-type-ref"
+								}
+							]
 						},
 						{
 							"match": "(@attribute)\\s+(\\*)",
 							"captures": {
 								"1": {
-									"name": "entity.name.type"
+									"name": "entity.name.tag"
 								},
 								"2": {
 									"name": "support.variable"
@@ -387,6 +388,22 @@
 				{
 					"name": "constant.character.escape",
 					"match": "\\\\."
+				}
+			]
+		},
+		"soy-type-ref": {
+			"patterns": [
+				{
+					"name": "support.type.primitive",
+					"match": "\\b(any|\\?|null|bool|int|float|number|string|html|js|uri|trusted_resource_uri|attributes|css|list|map|ve|ve_data)\\b"
+				},
+				{
+					"match": "\\b(\\w+):",
+					"captures": {
+						"1":{
+							"name": "variable.other.property"
+						}
+					}
 				}
 			]
 		}


### PR DESCRIPTION
Improving the highlighting for types in @param. 
Before:
![image](https://user-images.githubusercontent.com/2884950/139526712-939e0ef6-7943-4eef-bda1-ff03212ca6f3.png)
After:
![image](https://user-images.githubusercontent.com/2884950/139526661-ec0c59b5-53de-4402-b009-a6cbbd0f0aae.png)
