### PR TITLE
Fix 'import' being matched mid sentence.

### DIFF
--- a/syntax/soy.tmLanguage.json
+++ b/syntax/soy.tmLanguage.json
@@ -267,7 +267,7 @@
 		},
 		"import": {
 			"name": "support.function",
-			"begin": "import",
+			"begin": "^import\\b",
 			"end": ";",
 			"beginCaptures": {
 				"0": {


### PR DESCRIPTION
Fix import being matched mid sentence by only matching it at the start of the line.