### PR TITLE
Add modifiable template syntax.

### DIFF
--- a/syntax/soy.tmLanguage.json
+++ b/syntax/soy.tmLanguage.json
@@ -95,7 +95,7 @@
 							}
 						},
 						{
-							"match": "\\b(deltemplate|template|element|call|delcall|dynacall|namespace|modname|package)\\b(?:\\s+([\\w\\d.]+))?",
+							"match": "\\b(deltemplate|template|element|call|delcall|dynacall|namespace|delpackage|modname|package)\\b(?:\\s+([\\w\\d.]+))?",
 							"captures": {
 								"1": {
 									"name": "entity.name.tag"

--- a/syntax/soy.tmLanguage.json
+++ b/syntax/soy.tmLanguage.json
@@ -95,7 +95,7 @@
 							}
 						},
 						{
-							"match": "\\b(deltemplate|template|element|call|delcall|dynacall|namespace|delpackage|package)\\b(?:\\s+([\\w\\d.]+))?",
+							"match": "\\b(deltemplate|template|element|call|delcall|dynacall|namespace|modname|package)\\b(?:\\s+([\\w\\d.]+))?",
 							"captures": {
 								"1": {
 									"name": "entity.name.tag"
@@ -117,7 +117,7 @@
 							}
 						},
 						{
-							"match": "\\b(kind|autoescape|allowemptydefault|variant|data|requirecsspath|cssprefix|cssbase|visibility|method|params|return|type|namespace|function|component|whitespace|meaning|desc|genders|alternateId)=",
+							"match": "\\b(kind|autoescape|allowemptydefault|variant|data|requirecsspath|cssprefix|cssbase|visibility|method|params|return|type|namespace|function|component|whitespace|meaning|desc|genders|alternateId|modifies|modifiable)=",
 							"captures": {
 								"1": {
 									"name": "support.function"


### PR DESCRIPTION
delpackage has been renamed modname and a new syntax for deltemplates has been added. See:
https://github.com/google/closure-templates/blob/master/documentation/reference/modifiable-templates.md